### PR TITLE
update to 1.0.1

### DIFF
--- a/Livr.podspec
+++ b/Livr.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "Livr"
-  s.version      = "1.0"
+  s.version      = "1.0.1"
   s.summary      = "Lightweight validator supporting Language Independent Validation Rules Specification"
 
   s.homepage     = "https://github.com/marinofelipe/swift-validator-livr"

--- a/Livr/Info.plist
+++ b/Livr/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0</string>
+	<string>1.0.1</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>NSPrincipalClass</key>


### PR DESCRIPTION
### Why?
To update to 1.0.1 release

### Changes
- update version in project and podspec
- last tag version had a warning in podspec validation

### [Issue](#12)